### PR TITLE
Draft: Adds generic error submission/handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "backtraceio"
 description = "Backtrace I/O error reporting for Rust applications"
 version = "0.2.0"
-authors = ["KrzaQ <krzaq@krzaq.cc>", "Will Andrews <will@firepipe.net>"]
+authors = ["KrzaQ <krzaq@krzaq.cc>", "Will Andrews <will@firepipe.net>", "Noah Hendrickson <turing.thesis@gmail.com>"]
 homepage = "https://backtrace.io/"
 repository = "https://github.com/backtrace-labs/backtrace-rust/"
 license = "MIT OR Apache-2.0"
@@ -15,3 +15,6 @@ rustc_version_runtime = "0.2"
 serde_json = "1.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+crossbeam-channel = "0.5.6"
+lazy_static = "1.4.0"
+arc-swap = "1.5.1"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ back to the user, in case there are additional attributes/annotations to be
 defined (described more in detail [here][1]). It should accept `&mut Report`,
 `&PanicInfo`, making any changes desired to the report.
 
-# Example
+### Example
 
 ```rust
 use backtraceio::Report;
@@ -49,6 +49,48 @@ fn main() {
     panic!("{:?}", 69);
 }
 
+```
+
+## Manual Error Submission
+
+We also offer a per error submission handler for logging
+individual errors/exceptions.
+
+This can be invoked by chaining the submit_error() method on any Result type.
+
+You'll need to pass your token and url to an init method first before error 
+submission works.
+
+### Report Modification 
+
+You can optionally pass in Option wrapped HashMaps of the attributes
+and annotations you wish to ammend to your report. the per error handler
+will handle ammending them to the report before submitting it.
+
+### Usage
+
+```rust
+use std::collections::HashMap;
+use std::fs::File;
+
+use backtraceio::ResultExt;
+
+fn main() {
+    
+    let attributes: HashMap<String, String> = HashMap::new();
+    let cpus = num_cpus::get();
+    let cpus = cpus.to_string();
+    attributes.insert(String::from("cpu.cores"), cpus);
+
+    backtraceio::init("<token>", "<url>", None, Some(attributes.clone()));
+
+    match std::fs::File::open("./this_file_does_not_exist").submit_error()
+    {
+        Ok(_) => (),
+        Err(e) => eprintln!("{}", e),
+    }
+
+}
 ```
 
 [1]: https://api.backtrace.io/#tag/submit-crash

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+use crossbeam_channel::select;
+use lazy_static::lazy_static;
+
+use crate::sender::submit;
+use crate::Report;
+use crate::SubmissionTarget;
+
+lazy_static! {
+    static ref SENDER: ArcSwapOption<crossbeam_channel::Sender<ErrorInfo>> =
+        ArcSwapOption::from(None);
+}
+
+struct ErrorInfo {
+    backtrace: backtrace::Backtrace,
+    error: String,
+}
+
+pub fn init(
+    token: &str,
+    url: &str,
+    annotations: Option<HashMap<String, String>>,
+    attributes: Option<HashMap<String, String>>,
+) {
+    let (sender, receiver) = crossbeam_channel::bounded(124);
+    SENDER.store(Some(Arc::new(sender)));
+
+    let target = SubmissionTarget {
+        token: String::from(token),
+        url: String::from(url),
+    };
+    let mut report = Report {
+        ..Default::default()
+    };
+
+    if let Some(annotations) = &annotations {
+        report
+            .annotations
+            .extend(annotations.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    if let Some(attributes) = &attributes {
+        report
+            .attributes
+            .extend(attributes.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    std::thread::spawn(move || {
+        let recv = &receiver;
+        loop {
+            select! {
+                recv(recv) -> error_info => {
+                    match error_info {
+                        Ok(error_info) => {
+                            let mut report = report.clone();
+                            let target = target.clone();
+
+                            report
+                                .attributes
+                                .insert(String::from("error.message"), error_info.error.to_string());
+
+                            submit(&target, &mut report, error_info.backtrace);
+                        },
+                        Err(e) => {
+                            eprintln!("Failed to recv error info: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+pub trait ResultExt<T, E: std::fmt::Display> {
+    fn submit_error(self) -> Result<T, E>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E>
+where
+    E: std::fmt::Display,
+{
+    fn submit_error(self) -> Result<T, E> {
+        match self {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                if let Some(sender) = SENDER.load_full() {
+                    let error_info = ErrorInfo {
+                        backtrace: backtrace::Backtrace::new(),
+                        error: e.to_string(),
+                    };
+
+                    if sender.try_send(error_info).is_err() {
+                        eprintln!("Failed to send data to channel");
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,14 @@
 #[macro_use]
 extern crate serde_json;
 
+mod error;
 mod sender;
 
 use std::collections::HashMap;
 use std::panic::PanicInfo;
+
+pub use error::init;
+pub use error::ResultExt;
 
 #[derive(Debug, Clone)]
 pub struct SubmissionTarget {
@@ -28,6 +32,14 @@ where
     };
 
     std::panic::set_hook(Box::new(move |panic_info| {
-        sender::submit(&submission_target, panic_info, &user_handler);
+        let mut r = Report {
+            ..Default::default()
+        };
+
+        user_handler(&mut r, panic_info);
+
+        let bt = backtrace::Backtrace::new();
+
+        sender::submit(&submission_target, &mut r, bt);
     }));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::env;
 
+use backtraceio::ResultExt;
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let progname = args.get(0).expect("should always have a program name");
@@ -22,11 +24,23 @@ fn main() {
         }
     }
 
+    backtraceio::init(&token, &url, None, Some(attributes.clone()));
+
     backtraceio::register_error_handler(url, token, move |r: &mut backtraceio::Report, _| {
-        for (key, value) in &attributes {
+        for (key, value) in &attributes.clone() {
             r.attributes.insert(key.to_string(), value.to_string());
         }
     });
+
+    match std::fs::File::open("./do_not_exist").submit_error() {
+        Ok(_) => {
+            eprintln!("No error");
+        }
+        Err(_) => {
+            eprintln!("Error");
+        }
+    }
+
     println!("Hello, world!");
     panic!("{}", panic_msg);
 }


### PR DESCRIPTION
Previously we could only submit panic based errors via registering a global error handler with the panic hook.

This adds a backing thread to handle submissions to backtrace and a submit_error() func we can chain on result types to send errors to the thread via a crossbeam channel.

Early draft, so I'm curious what folks think.