### PR TITLE
Add hostname attribute if it doesn't already exist.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rustc_version_runtime = "0.2"
 serde_json = "1.0"
 uuid = { version = "0.8.2", features = ["v4"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+gethostname = "0.4.1"

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::panic::PanicInfo;
 use std::time;
 
+use gethostname::gethostname;
+
 use crate::Report;
 use crate::SubmissionTarget;
 
@@ -61,6 +63,17 @@ where
             elem.insert(String::from("address"), addr);
             elem.insert(String::from("funcName"), name);
             stack.push(elem);
+        }
+    }
+
+    // We should only add a hostname attribute only if it does not
+    // already exist in a reports attributes.
+    //
+    // If we fail to access the hostname of the system reporting this crash
+    // it's fine to not attempt adding it to the report and leaving it null.
+    if !r.attributes.contains_key("hostname") {
+        if let Ok(hostname) = gethostname().into_string() {
+            r.attributes.insert(String::from("hostname"), hostname);
         }
     }
 


### PR DESCRIPTION
As the title says, if a reports attributes doesn't already have the hostname attribute set then attempt to set it.

If we fail to get the hostname from a instance then it's fine to just leave the hostname attribute null.